### PR TITLE
Add anagrams detection functionality and tests

### DIFF
--- a/anagram/Anagram.ps1
+++ b/anagram/Anagram.ps1
@@ -1,0 +1,33 @@
+Function Invoke-Anagram() {
+    <#
+    .SYNOPSIS
+    Determine if a word is an anagram of other words in a list.
+
+    .DESCRIPTION
+    An anagram is a word formed by rearranging the letters of another word, e.g., spar, formed from rasp.
+    Given a word and a list of possible anagrams, find the anagrams in the list.
+
+    .PARAMETER Subject
+    The word to check
+
+    .PARAMETER Candidates
+    The list of possible anagrams
+
+    .EXAMPLE
+    Invoke-Anagram -Subject "listen" -Candidates @("enlists" "google" "inlets" "banana")
+    #>
+    [CmdletBinding()]
+    Param(
+        [string]$Subject,
+        [string[]]$Candidates
+    )
+
+    $letters = -join ($Subject.ToLower().ToCharArray() | Sort-Object)
+
+    $isAnagram = {
+        $candidate = -join ($_.ToLower().ToCharArray() | Sort-Object)
+        $_ -ne $Subject -and $candidate -eq $letters
+    }
+
+    $Candidates | Where-Object $isAnagram
+}

--- a/anagram/Anagram.tests.ps1
+++ b/anagram/Anagram.tests.ps1
@@ -1,0 +1,117 @@
+BeforeAll {
+    . "./Anagram.ps1"
+}
+
+Describe "Test Invoke-Anagram.ps1" {
+    It "no matches" {
+        $got = Invoke-Anagram -Subject "diaper" -Candidates @("hello", "world", "zombies", "pants")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "detects two anagrams" {
+        $got = Invoke-Anagram -Subject "solemn" -Candidates @("lemons", "cherry", "melons")
+        $want = @("lemons", "melons")
+
+        $got | Should -Be $want
+    }
+
+    It "does not detect anagram subsets" {
+        $got = Invoke-Anagram -Subject "good" -Candidates @("dog", "goody")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "detects anagram" {
+        $got = Invoke-Anagram -Subject "listen" -Candidates @("enlists", "google", "inlets", "banana")
+        $want = @("inlets")
+
+        $got | Should -Be $want
+    }
+
+    It "detects three anagrams" {
+        $got = Invoke-Anagram -Subject "allergy" -Candidates @("gallery", "ballerina", "regally", "clergy", "largely", "leading")
+        $want = @("gallery", "regally", "largely")
+
+        $got | Should -Be $want
+    }
+
+    It "detects multiple anagrams with different case" {
+        $got = Invoke-Anagram -Subject "nose" -Candidates @("Eons", "ONES")
+        $want = @("Eons", "ONES")
+
+        $got | Should -Be $want
+    }
+
+    It "does not detect non-anagrams with identical checksum" {
+        $got = Invoke-Anagram -Subject "mass" -Candidates @("last")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "detects anagrams case-insensitively" {
+        $got = Invoke-Anagram -Subject "Orchestra" -Candidates @("cashregister", "Carthorse", "radishes")
+        $want = @("Carthorse")
+
+        $got | Should -Be $want
+    }
+
+    It "detects anagrams using case-insensitive subject" {
+        $got = Invoke-Anagram -Subject "Orchestra" -Candidates @("cashregister", "carthorse", "radishes")
+        $want = @("carthorse")
+
+        $got | Should -Be $want
+    }
+
+    It "detects anagrams using case-insensitive possible matches" {
+        $got = Invoke-Anagram -Subject "orchestra" -Candidates @("cashregister", "Carthorse", "radishes")
+        $want = @("Carthorse")
+
+        $got | Should -Be $want
+    }
+
+    It "does not detect a anagram if the original word is repeated" {
+        $got = Invoke-Anagram -Subject "go" -Candidates @("go Go GO")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "anagrams must use all letters exactly once" {
+        $got = Invoke-Anagram -Subject "tapper" -Candidates @("patter")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "words are not anagrams of themselves" {
+        $got = Invoke-Anagram -Subject "BANANA" -Candidates @("BANANA")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "words are not anagrams of themselves even if letter case is partially different" {
+        $got = Invoke-Anagram -Subject "BANANA" -Candidates @("Banana")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "words are not anagrams of themselves even if letter case is completely different" {
+        $got = Invoke-Anagram -Subject "BANANA" -Candidates @("banana")
+        $want = @()
+
+        $got | Should -Be $want
+    }
+
+    It "words other than themselves can be anagrams" {
+        $got = Invoke-Anagram -Subject "LISTEN" -Candidates @("Listen", "Silent")
+        $want = @("Silent")
+
+        $got | Should -Be $want
+    }
+}

--- a/anagram/README.md
+++ b/anagram/README.md
@@ -1,0 +1,28 @@
+# Anagram
+
+Welcome to Anagram on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+An anagram is a rearrangement of letters to form a new word: for example `"owns"` is an anagram of `"snow"`.
+A word is not its own anagram: for example, `"stop"` is not an anagram of `"stop"`.
+
+Given a target word and a set of candidate words, this exercise requests the anagram set: the subset of the candidates that are anagrams of the target.
+
+The target and candidates are words of one or more ASCII alphabetic characters (`A`-`Z` and `a`-`z`).
+Lowercase and uppercase characters are equivalent: for example, `"PoTS"` is an anagram of `"sTOp"`, but `StoP` is not an anagram of `sTOp`.
+The anagram set is the subset of the candidate set that are anagrams of the target (in any order).
+Words in the anagram set should have the same letter case as in the candidate set.
+
+Given the target `"stone"` and candidates `"stone"`, `"tones"`, `"banana"`, `"tons"`, `"notes"`, `"Seton"`, the anagram set is `"tones"`, `"notes"`, `"Seton"`.
+
+## Source
+
+### Created by
+
+- @meatball133
+
+### Based on
+
+Inspired by the Extreme Startup game - https://github.com/rchatley/extreme_startup


### PR DESCRIPTION
This commit introduces a new functionality that allows detecting anagrams in an input list of words. A corresponding PowerShell script and a unit test file have also been added to ensure the correct functionality of the operation. The Anagram.ps1 script takes a subject word and a list of candidate words, and then identifies the subset that consists of anagrams of the subject word.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a feature to determine if a given word is an anagram of any words in a provided list, enhancing word comparison capabilities.
- **Tests**
	- Added test cases to ensure the reliability of the anagram detection functionality.
- **Documentation**
	- Updated documentation with an exercise to help users understand and engage with the new anagram identification feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->