### PR TITLE
Add Armstrong number determination functionality

### DIFF
--- a/armstrong-numbers/ArmstrongNumbers.ps1
+++ b/armstrong-numbers/ArmstrongNumbers.ps1
@@ -1,0 +1,28 @@
+Function Invoke-ArmstrongNumbers() {
+    <#
+    .SYNOPSIS
+    Determine if a number is an Armstrong number.
+
+    .DESCRIPTION
+    An Armstrong number is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+    .PARAMETER Number
+    The number to check.
+
+    .EXAMPLE
+    Invoke-ArmstrongNumbers -Number 12
+    #>
+    [CmdletBinding()]
+    Param(
+        [Int64]$Number
+    )
+
+    $exponent = $Number.ToString().Length
+
+    $sumOfDigits = $Number.ToString().ToCharArray() | 
+    ForEach-Object { [Math]::Pow([int]::Parse($_), $exponent) } |
+    Measure-Object -Sum | 
+    Select-Object -ExpandProperty Sum
+
+    $sumOfDigits -eq $Number
+}

--- a/armstrong-numbers/ArmstrongNumbers.tests.ps1
+++ b/armstrong-numbers/ArmstrongNumbers.tests.ps1
@@ -1,0 +1,68 @@
+BeforeAll {
+    . "./ArmstrongNumbers.ps1"
+}
+
+Describe "Test Invoke-ArmstrongNumbers.ps1" {
+    It "Zero is an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 0
+        $want = $True
+
+        $got | Should -Be $want
+    }
+
+    It "Single-digit numbers are Armstrong numbers" {
+        $got = Invoke-ArmstrongNumbers -Number 5
+        $want = $True
+
+        $got | Should -BeExactly $want
+    }
+
+    It "There are no two-digit Armstrong numbers" {
+        $got = Invoke-ArmstrongNumbers -Number 10
+        $want = $False
+
+        $got | Should -BeExactly $want
+    }
+    
+    It "Three-digit number that is an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 153
+        $want = $True
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Three-digit number that is not an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 100
+        $want = $False
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Four-digit number that is an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 9474
+        $want = $True
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Four-digit number that is not an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 9475
+        $want = $False
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Seven-digit number that is an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 9926315
+        $want = $True
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Seven-digit number that is not an Armstrong number" {
+        $got = Invoke-ArmstrongNumbers -Number 9926314
+        $want = $False
+
+        $got | Should -BeExactly $want
+    }
+}

--- a/armstrong-numbers/README.md
+++ b/armstrong-numbers/README.md
@@ -1,0 +1,29 @@
+# Armstrong Numbers
+
+Welcome to Armstrong Numbers on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+An [Armstrong number][armstrong-number] is a number that is the sum of its own digits each raised to the power of the number of digits.
+
+For example:
+
+- 9 is an Armstrong number, because `9 = 9^1 = 9`
+- 10 is *not* an Armstrong number, because `10 != 1^2 + 0^2 = 1`
+- 153 is an Armstrong number, because: `153 = 1^3 + 5^3 + 3^3 = 1 + 125 + 27 = 153`
+- 154 is *not* an Armstrong number, because: `154 != 1^3 + 5^3 + 4^3 = 1 + 125 + 64 = 190`
+
+Write some code to determine whether a number is an Armstrong number.
+
+[armstrong-number]: https://en.wikipedia.org/wiki/Narcissistic_number
+
+## Source
+
+### Created by
+
+- @meatball133
+
+### Based on
+
+Wikipedia - https://en.wikipedia.org/wiki/Narcissistic_number


### PR DESCRIPTION
This commit introduces an `Invoke-ArmstrongNumbers` function in PowerShell. This function determines whether a number is an Armstrong number by comparing it to the sum of its digits each raised to the number of digits. Additionally, relevant tests and a detailed `README.md` file explaining the concept of Armstrong numbers has been added.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new feature to determine if a given number is an Armstrong number through a PowerShell function.

- **Tests**
	- Added comprehensive test cases covering various scenarios for Armstrong number validation.

- **Documentation**
	- Published a README explaining the concept of Armstrong Numbers, with examples and instructions for users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->