### PR TITLE
Add grade-school exercise to PowerShell track

### DIFF
--- a/grade-school/GradeSchool.ps1
+++ b/grade-school/GradeSchool.ps1
@@ -1,0 +1,60 @@
+<#
+.SYNOPSIS
+    Given students' names along with the grade that they are in, create a roster for the school.
+.DESCRIPTION
+    Add a student's name to the roster for a grade
+    "Add Jim to grade 2."
+    "OK."
+    Get a list of all students enrolled in a grade
+    "Which students are in grade 2?"
+    "We've only got Jim just now."
+    Get a sorted list of all students in all grades. Grades should sort as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
+    "Who all is enrolled in school right now?"
+    "Grade 1: Anna, Barb, and Charlie. Grade 2: Alex, Peter, and Zoe. Grade 3…"
+    Note that all our students only have one name. (It's a small town, what do you want?)
+.EXAMPLE
+    $roster = [Roster]::new()
+    $roster.AddStudent(1,'Billy')
+    $roster.AddStudent(1,'Josh')
+    $roster.AddStudent(2,'Allison')
+    $roster.GetRoster()
+    $roster.GetRoster(2)
+
+    This will create a new roster and add 3 students to it.
+    When no arguments are supplied to the GetRoster method, all students will be returned.
+    When a grade number is supplied to the GetRoster method, students from that grade will be returned.
+#>
+
+class Student {
+    [int] $Grade
+    [string] $Name
+
+    Student ([int]$grade, [string]$name) {
+        $this.Grade = $grade
+        $this.Name = $name
+    }
+}
+
+class Roster {
+    [Hashtable] $roster = @{}
+
+    Roster() {
+
+    }
+
+    [bool] AddStudent([int]$grade, [string]$name)  {
+        if ($this.GetRoster().Name -contains $name) {
+            return $false
+        }
+        if (-not $this.roster.ContainsKey($grade)) {
+            $students = New-Object System.Collections.ArrayList
+            $this.roster.Add($grade, $students)
+        }
+        $this.roster[$grade].Add([Student]::new($grade, $name))
+        return $true
+    }
+
+    [Student[]] GetRoster() {
+        return $this.roster.Values | ForEach-Object { $_ }
+    }
+}

--- a/grade-school/GradeSchool.tests.ps1
+++ b/grade-school/GradeSchool.tests.ps1
@@ -1,0 +1,158 @@
+BeforeAll {
+    . "./GradeSchool.ps1"
+}
+
+Describe "Grade School Test cases" {
+    It "Roster is empty when no student is added"{
+        $roster = [Roster]::new()
+        $roster.GetRoster() | Should -BeNullOrEmpty
+    }
+
+    It "Add a student" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Aimee') | Should -Be $true
+    }
+
+    It "Student is added to the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Aimee') | Should -Be $true
+        $roster.GetRoster().Name | Should -Be 'Aimee'
+    }
+
+    It "Adding multiple students in the same grade in the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair') | Should -Be $true
+        $roster.AddStudent(2,'James') | Should -Be $true
+        $roster.AddStudent(2,'Paul') | Should -Be $true
+    }
+
+    It "Multiple students in the same grade are added to the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(2,'Paul')
+        $roster.GetRoster().Name | Should -Be ('Blair', 'James', 'Paul')
+    }
+
+    It "Cannot add student to same grade in the roster more than once" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair') | Should -Be $true
+        $roster.AddStudent(2,'James') | Should -Be $true
+        $roster.AddStudent(2,'James') | Should -Be $false
+        $roster.AddStudent(2,'Paul') | Should -Be $true
+    }
+
+    It "A student can't be in two different grades" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Aimee')
+        $roster.AddStudent(2,'Aimee') 
+        $roster.GetRoster().Name | Should -Be 'Aimee'
+    }
+
+    It "Student not added to same grade in the roster more than once" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(2,'Paul')
+        $roster.GetRoster().Name | Should -Be ('Blair', 'James', 'Paul')
+    }
+
+    It "Adding students in multiple grades" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(3,'Chelsea') | Should -Be $true
+        $roster.AddStudent(7,'Logan') | Should -Be $true
+    }
+
+    It "Students in multiple grades are added to the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(3,'Chelsea')
+        $roster.AddStudent(7,'Logan')
+        $roster.GetRoster().Name | Should -Be ('Chelsea', 'Logan')
+    }
+
+    It "Cannot add same student to multiple grades in the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair') | Should -Be $true
+        $roster.AddStudent(2,'James') | Should -Be $true
+        $roster.AddStudent(3,'James') | Should -Be $false
+        $roster.AddStudent(3,'Paul') | Should -Be $true
+    }
+
+    It  "Students are sorted by grades in the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(3,'Jim')
+        $roster.AddStudent(2,'Peter')
+        $roster.AddStudent(1,'Anna')
+        $roster.GetRoster().Name | Should -Be ('Anna', 'Peter', 'Jim')
+    }
+
+    It "Students are sorted by name in the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Peter')
+        $roster.AddStudent(2,'Zoe')
+        $roster.AddStudent(2,'Alex')
+        $roster.GetRoster().Name | Should -Be ('Alex', 'Peter', 'Zoe')
+    }
+
+    It "Students are sorted by grades and then by name in the roster" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'peter')
+        $roster.AddStudent(1,'Anna')
+        $roster.AddStudent(1,'Barb')
+        $roster.AddStudent(2,'Zoe')
+        $roster.AddStudent(2,'Alex')
+        $roster.AddStudent(3,'Jim')
+        $roster.AddStudent(1,'Charlie')
+        $roster.GetRoster().Name | Should -Be ('Anna', 'Barb', 'Charlie', 'Alex', 'Peter', 'Zoe', 'Jim')
+    }
+
+    It "Grade is empty if no students in the roster" {
+        $roster = [Roster]::new()
+        $roster.GetRoster(1).Name | Should -BeNullOrEmpty
+    }
+
+    It "Grade is empty if no students in that grade" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Peter')
+        $roster.AddStudent(2,'Zoe')
+        $roster.AddStudent(2,'Alex')
+        $roster.AddStudent(3,'Jim')
+        $roster.GetRoster(1).Name | Should -BeNullOrEmpty
+    }
+
+    It "Student not added to same grade more than once" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(2,'Paul')
+        $roster.GetRoster(2).Name | Should -Be ('Blair', 'James', 'Paul')
+    }
+
+    It "Student not added to multiple grades" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(3,'James')
+        $roster.AddStudent(3,'Paul')
+        $roster.GetRoster(2).Name | Should -Be ('Blair', 'James')
+    }
+
+    It "Student not added to other grade for multiple grades" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(2,'Blair')
+        $roster.AddStudent(2,'James')
+        $roster.AddStudent(3,'James')
+        $roster.AddStudent(3,'Paul')
+        $roster.GetRoster(3).Name | Should -Be ('Paul')
+    }
+
+    It "Students are sorted by name in a grade" {
+        $roster = [Roster]::new()
+        $roster.AddStudent(5,'Franklin')
+        $roster.AddStudent(5,'Bradley')
+        $roster.AddStudent(1,'Jeff')
+        $roster.GetRoster(5).Name | Should -Be ('Bradley', 'Franklin')
+    }
+}

--- a/grade-school/README.md
+++ b/grade-school/README.md
@@ -1,0 +1,37 @@
+# Grade School
+
+Welcome to Grade School on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given students' names along with the grade that they are in, create a roster for the school.
+
+In the end, you should be able to:
+
+- Add a student's name to the roster for a grade
+  - "Add Jim to grade 2."
+  - "OK."
+- Get a list of all students enrolled in a grade
+  - "Which students are in grade 2?"
+  - "We've only got Jim just now."
+- Get a sorted list of all students in all grades.
+  Grades should sort as 1, 2, 3, etc., and students within a grade should be sorted alphabetically by name.
+  - "Who all is enrolled in school right now?"
+  - "Let me think.
+    We have Anna, Barb, and Charlie in grade 1, Alex, Peter, and Zoe in grade 2 and Jim in grade 5.
+    So the answer is: Anna, Barb, Charlie, Alex, Peter, Zoe and Jim"
+
+Note that all our students only have one name (It's a small town, what do you want?) and each student cannot be added more than once to a grade or the roster.
+In fact, when a test attempts to add the same student more than once, your implementation should indicate that this is incorrect.
+
+## Source
+
+### Created by
+
+- @inammathe
+- @meatball133
+
+### Based on
+
+A pairing session with Phil Battos at gSchool


### PR DESCRIPTION
This commit introduces the grade-school exercise to the PowerShell track. The GradeSchool.ps1 script includes the implementation of a roster for a school with methods to add students' names along with the grade they're in. GradeSchool.test.ps1 sets up the tests for functionality such as adding students, checking who's enrolled in certain grades, and ensuring students are appropriately sorted by grade and name.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a Grade School management system enabling:
		- Addition of students to specific grades.
		- Retrieval of students by grade.
		- Acquisition of a sorted list of all students across grades.

- **Documentation**
	- Added a README explaining the new Grade School roster management feature.

- **Tests**
	- Implemented test cases for the Grade School class, covering:
		- Student addition and uniqueness.
		- Sorting by grade and name.
		- General roster operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->