### PR TITLE
Add Matching Brackets exercise to PowerShell track

### DIFF
--- a/matching-brackets/MatchingBrackets.ps1
+++ b/matching-brackets/MatchingBrackets.ps1
@@ -1,0 +1,45 @@
+Function Test-MatchingBrackets() {
+    <#
+    .SYNOPSIS
+    Determine if all brackets inside a string paired and nested correctly.
+    
+    .DESCRIPTION
+    Given a string containing brackets `[]`, braces `{}`, parentheses `()`, or any combination thereof, verify that any and all pairs are matched and nested correctly.
+    The string may also contain other characters, which for the purposes of this exercise should be ignored.
+    
+    .PARAMETER Text
+    The string to be verified.
+    
+    .EXAMPLE
+    Test-MatchingBrackets("[]") => True
+    Test-MatchingBrackets("[)]") => False
+    #>
+    [CmdletBinding()]
+    Param(
+        [string]$Text
+    )
+
+    $brackets = @{
+        '[' = ']'
+        '{' = '}'
+        '(' = ')'
+    }
+    $chars = ($Text -replace '[^[\](){}]', '').ToCharArray()
+    $stack = New-Object System.Collections.Stack
+    
+    foreach ($char in $chars) {
+        $current = $char.ToString()
+        if ($brackets.ContainsKey($current)) {
+            $stack.Push($current)
+            continue
+        } 
+        if ($stack.Count -eq 0) {
+            return $false
+        }
+        $last = $stack.Pop()
+        if ($brackets[$last] -ne $current) {
+            return $false
+        }
+    }
+    return $stack.Count -eq 0
+}

--- a/matching-brackets/MatchingBrackets.tests.ps1
+++ b/matching-brackets/MatchingBrackets.tests.ps1
@@ -1,0 +1,126 @@
+BeforeAll {
+    . ".\MatchingBrackets.ps1"
+}
+
+Describe "Matching brackets test cases" {
+    It "paired square brackets" {
+        $got  = Test-MatchingBrackets("[]")
+
+        $got | Should -Be $true
+    }
+    
+    It "empty string" {
+        $got  = Test-MatchingBrackets("")
+
+        $got | Should -Be $true
+    }
+    
+    It "unpaired brackets" {
+        $got  = Test-MatchingBrackets("[[")
+
+        $got | Should -Be $false
+    }
+    
+    It "wrong ordered brackets" {
+        $got  = Test-MatchingBrackets("}{")
+
+        $got | Should -Be $false
+    }
+    
+    It "wrong closing bracket" {
+        $got  = Test-MatchingBrackets("{]")
+
+        $got | Should -Be $false
+    }
+    
+    It "paired with whitespace" {
+        $got  = Test-MatchingBrackets("{  }")
+
+        $got | Should -Be $true
+    }
+    
+    It "partially paired brackets" {
+        $got  = Test-MatchingBrackets("{[])")
+
+        $got | Should -Be $false
+    }
+    
+    It "simple nested brackets" {
+        $got  = Test-MatchingBrackets("{[]}")
+
+        $got | Should -Be $true
+    }
+    
+    It "several paired brackets" {
+        $got  = Test-MatchingBrackets("{}[]")
+
+        $got | Should -Be $true
+    }
+    
+    It "paired and nested brackets" {
+        $got  = Test-MatchingBrackets("([{}({}[])])")
+
+        $got | Should -Be $true
+    }
+    
+    It "unopened closing brackets" {
+        $got  = Test-MatchingBrackets("{[)][]}")
+
+        $got | Should -Be $false
+    }
+    
+    It "unpaired and nested brackets" {
+        $got  = Test-MatchingBrackets("([{])")
+
+        $got | Should -Be $false
+    }
+    
+    It "paired and wrong nested brackets" {
+        $got  = Test-MatchingBrackets("[({]})")
+
+        $got | Should -Be $false
+    }
+    
+    It "paired and wrong nested brackets but innermost are correct" {
+        $got  = Test-MatchingBrackets("[({}])")
+
+        $got | Should -Be $false
+    }
+    
+    It "paired and incomplete brackets" {
+        $got  = Test-MatchingBrackets("{}[")
+
+        $got | Should -Be $false
+    }
+    
+    It "too many closing brackets" {
+        $got  = Test-MatchingBrackets("[]]")
+
+        $got | Should -Be $false
+    }
+    
+    It "early unexpected brackets" {
+        $got  = Test-MatchingBrackets(")()")
+
+        $got | Should -Be $false
+    }
+    
+    It "early mismatched brackets" {
+        $got  = Test-MatchingBrackets("{)()")
+
+        $got | Should -Be $false
+    }
+    
+    It "math expression" {
+        $got  = Test-MatchingBrackets("(((185 + 223.85) * 15) - 543)/2")
+
+        $got | Should -Be $true
+    }
+    
+    It "complex latex expression" {
+        $complexString = "\\left(\\begin{array}{cc} \\frac{1}{3} & x\\\\ \\mathrm{e}^{x} &... x^2 \\end{array}\\right)"
+        $got  = Test-MatchingBrackets($complexString)
+
+        $got | Should -Be $true
+    }
+}

--- a/matching-brackets/README.md
+++ b/matching-brackets/README.md
@@ -1,0 +1,19 @@
+# Matching Brackets
+
+Welcome to Matching Brackets on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Given a string containing brackets `[]`, braces `{}`, parentheses `()`, or any combination thereof, verify that any and all pairs are matched and nested correctly.
+The string may also contain other characters, which for the purposes of this exercise should be ignored.
+
+## Source
+
+### Created by
+
+- @glaxxie
+
+### Based on
+
+Ginna Baker


### PR DESCRIPTION
This commit introduces the "Matching Brackets" exercise to the PowerShell track on Exercism. It includes a README with instructions, a suite of tests in 'MatchingBrackets.tests.ps1', and a basic solution in 'MatchingBrackets.ps1'. The exercise focuses on validating the nesting and pairing of brackets, braces, and parentheses in a given string.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new "Matching Brackets" exercise, allowing users to check the correctness of bracket pairing in strings.
- **Tests**
	- Added test cases for the "Matching Brackets" functionality, covering paired, nested, and mismatched brackets scenarios.
- **Documentation**
	- Published a README for the "Matching Brackets" exercise, detailing the challenge and objectives.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->