### PR TITLE
Add Invoke-MicroBlog function and tests

### DIFF
--- a/micro-blog/MicroBlog.ps1
+++ b/micro-blog/MicroBlog.ps1
@@ -1,0 +1,23 @@
+Function Invoke-MicroBlog() {
+    <#
+    .SYNOPSIS
+    Implement a function to make micro blog post that only of 5 or less characters.
+
+    .DESCRIPTION
+    Given a string, truncate it into a string of maximum 5 characters.
+
+    .PARAMETER Post
+    A string object contains Unicode text encoding: alphabets, symbols or even emojis.
+
+    .EXAMPLE
+    Invoke-MicroBlog -Post "Lightning"
+    Returns: "Light"
+    #>
+    [CmdletBinding()]
+    Param(
+        [string]$Post
+    )
+    Add-Type -AssemblyName System.Globalization
+    $stringInfo = [System.Globalization.StringInfo]::new($Post)
+    $stringInfo.SubstringByTextElements(0, [Math]::Min(5, $stringInfo.LengthInTextElements))
+}

--- a/micro-blog/MicroBlog.tests.ps1
+++ b/micro-blog/MicroBlog.tests.ps1
@@ -1,0 +1,118 @@
+BeforeAll {
+    . "./MicroBlog.ps1"
+}
+
+Describe "MicroBlog test cases" {
+    It "English language short" {
+        $got  = Invoke-MicroBlog("Hi")
+        $want = "Hi"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "English language long" {
+        $got  = Invoke-MicroBlog("Hello there")
+        $want = "Hello"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "German language short (broth)" {
+        $got  = Invoke-MicroBlog("brühe")
+        $want = "brühe"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "German language long (bear carpet → beards)" {
+        $got  = Invoke-MicroBlog("Bärteppich")
+        $want = "Bärte"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Bulgarian language short (good)" {
+        $got  = Invoke-MicroBlog("Добър")
+        $want = "Добър"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Greek language short (health)" {
+        $got  = Invoke-MicroBlog("υγειά")
+        $want = "υγειά"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Maths short" {
+        $got  = Invoke-MicroBlog("a=πr²")
+        $want = "a=πr²"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Maths long" {
+        $got  = Invoke-MicroBlog("∅⊊ℕ⊊ℤ⊊ℚ⊊ℝ⊊ℂ")
+        $want = "∅⊊ℕ⊊ℤ"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "English and emoji short" {
+        $got  = Invoke-MicroBlog("Fly 🛫")
+        $want = "Fly 🛫"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Emoji short" {
+        $got  = Invoke-MicroBlog("💇")
+        $want = "💇"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Emoji long" {
+        $got  = Invoke-MicroBlog("❄🌡🤧🤒🏥🕰😀")
+        $want = "❄🌡🤧🤒🏥"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Royal Flush?" {
+        $got  = Invoke-MicroBlog("🃎🂸🃅🃋🃍🃁🃊")
+        $want = "🃎🂸🃅🃋🃍"
+
+        $got | Should -BeExactly $want
+    }
+
+    #Those below are extra tests for this track
+    It "Chess pieces" {
+        $got  = Invoke-MicroBlog("♜♞♝♛♚♟︎")
+        $want = "♜♞♝♛♚"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Zodiac signs" {
+        $got  = Invoke-MicroBlog("♈︎♉︎♊︎♋︎♌︎♍︎♎︎♏︎♐︎♑︎♒︎♓︎")
+        $want = "♈︎♉︎♊︎♋︎♌︎"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Music notes" {
+        $got  = Invoke-MicroBlog("𝄠♭𝅘𝅥𝆕♫♬𝅘𝅥𝅯♯")
+        $want = "𝄠♭𝅘𝅥𝆕♫"
+
+        $got | Should -BeExactly $want
+    }
+
+    It "Egyptian Hieroglyphs" {
+        $got  = Invoke-MicroBlog("𓂀𓅁𓅊𓁁☥𓁏")
+        $want = "𓂀𓅁𓅊𓁁☥"
+
+        $got | Should -BeExactly $want
+    }
+}

--- a/micro-blog/README.md
+++ b/micro-blog/README.md
@@ -1,0 +1,51 @@
+# Micro Blog
+
+Welcome to Micro Blog on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+You have identified a gap in the social media market for very very short posts.
+Now that Twitter allows 280 character posts, people wanting quick social media updates aren't being served.
+You decide to create your own social media network.
+
+To make your product noteworthy, you make it extreme and only allow posts of 5 or less characters.
+Any posts of more than 5 characters should be truncated to 5.
+
+To allow your users to express themselves fully, you allow Emoji and other Unicode.
+
+The task is to truncate input strings to 5 characters.
+
+## Text Encodings
+
+Text stored digitally has to be converted to a series of bytes.
+There are 3 ways to map characters to bytes in common use.
+
+- **ASCII** can encode English language characters.
+  All characters are precisely 1 byte long.
+- **UTF-8** is a Unicode text encoding.
+  Characters take between 1 and 4 bytes.
+- **UTF-16** is a Unicode text encoding.
+  Characters are either 2 or 4 bytes long.
+
+UTF-8 and UTF-16 are both Unicode encodings which means they're capable of representing a massive range of characters including:
+
+- Text in most of the world's languages and scripts
+- Historic text
+- Emoji
+
+UTF-8 and UTF-16 are both variable length encodings, which means that different characters take up different amounts of space.
+
+Consider the letter 'a' and the emoji '😛'.
+In UTF-16 the letter takes 2 bytes but the emoji takes 4 bytes.
+
+The trick to this exercise is to use APIs designed around Unicode characters (codepoints) instead of Unicode codeunits.
+
+## Powershell Resource
+Powershell utilize a lot of built in .NET classes, for this exercise you should consider taking a look at this [page](https://learn.microsoft.com/en-us/dotnet/api/system.globalization.stringinfo) to work with the API.
+
+## Source
+
+### Created by
+
+- @glaxxie


### PR DESCRIPTION
Implemented a new PowerShell function, `Invoke-MicroBlog`, to truncate an input string to 5 characters or less. Added a comprehensive set of test cases to verify functionality across a range of inputs, including different languages, symbols and emojis.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new PowerShell function for microblogging that truncates strings to 5 characters, supporting Unicode text including emojis, symbols, and various languages.
- **Tests**
	- Added comprehensive test cases for the new microblogging function, covering a wide range of characters and symbols across different languages.
- **Documentation**
	- Published a README explaining the concept of microblogging with extremely short posts, detailing the handling of text encodings and Unicode characters in PowerShell.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->