### PR TITLE
Add Get-MeetUp function and tests

### DIFF
--- a/meetup/Meetup.ps1
+++ b/meetup/Meetup.ps1
@@ -1,0 +1,36 @@
+Function Get-MeetUp {
+    <#
+    .SYNOPSIS
+    In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
+    
+    .DESCRIPTION
+    Given information for a meep up : year, month, weekday and schedule, return a datetime object of the meetup date.
+    
+    .PARAMETER Year
+    The year of the meetup date.
+
+    .PARAMETER Month
+    The month of the meetup date.
+
+    .PARAMETER Weekday
+    The weekday of the meetup date.
+
+    .PARAMETER Schedule
+    The position of the specified weekday within the month.
+    
+    .EXAMPLE
+    Get-MeetUp -Year 2002 -Month 12 -Weekday Monday -Schedule first
+    Return: Monday, December 2, 2002 00:00:00 
+
+    Note: 00:00:00 is just an example, Get-Date will return the current time (hour, min) based on your system unless you specify them.
+    #>
+    param(
+        [int]$year,
+        [int]$month,
+        [string]$weekday,
+        [string]$schedule
+    )
+
+    
+    Throw "Please implement this function"
+}

--- a/meetup/Meetup.tests.ps1
+++ b/meetup/Meetup.tests.ps1
@@ -1,0 +1,171 @@
+BeforeAll {
+    . "./Meetup.ps1"
+}
+
+Describe "Meetup test cases" {
+    Context "Monday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -TestCases @(
+            @{ year = 2013; month = 5; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-05-13' }
+            @{ year = 2013; month = 8; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-08-19' }
+            @{ year = 2013; month = 9; weekday = 'Monday'; schedule = 'teenth'; expect = '2013-09-16' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'first' ; expect = '2013-03-04' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'first' ; expect = '2013-04-01' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'second'; expect = '2013-03-11' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'second'; expect = '2013-04-08' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'third' ; expect = '2013-03-18' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'third' ; expect = '2013-04-15' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'fourth'; expect = '2013-03-25' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'fourth'; expect = '2013-04-22' }
+            @{ year = 2013; month = 3; weekday = 'Monday'; schedule = 'last'  ; expect = '2013-03-25' }
+            @{ year = 2013; month = 4; weekday = 'Monday'; schedule = 'last'  ; expect = '2013-04-29' }
+        ) { 
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Tuesday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 3; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-03-19' }
+            @{ year = 2013; month = 4; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-04-16' }
+            @{ year = 2013; month = 8; weekday = 'Tuesday'; schedule = 'teenth'; expect = '2013-08-13' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'first' ; expect = '2013-05-07' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'first' ; expect = '2013-06-04' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'second'; expect = '2013-05-14' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'second'; expect = '2013-06-11' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'third' ; expect = '2013-05-21' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'third' ; expect = '2013-06-18' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'fourth'; expect = '2013-05-28' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'fourth'; expect = '2013-06-25' }
+            @{ year = 2013; month = 5; weekday = 'Tuesday'; schedule = 'last'  ; expect = '2013-05-28' }
+            @{ year = 2013; month = 6; weekday = 'Tuesday'; schedule = 'last'  ; expect = '2013-06-25' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Wednesday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 1 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-01-16' }
+            @{ year = 2013; month = 2 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-02-13' }
+            @{ year = 2013; month = 6 ; weekday = 'Wednesday'; schedule = 'teenth'; expect = '2013-06-19' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'first' ; expect = '2013-07-03' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'first' ; expect = '2013-08-07' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'second'; expect = '2013-07-10' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'second'; expect = '2013-08-14' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'third' ; expect = '2013-07-17' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'third' ; expect = '2013-08-21' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'fourth'; expect = '2013-07-24' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'fourth'; expect = '2013-08-28' }
+            @{ year = 2013; month = 7 ; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2013-07-31' }
+            @{ year = 2013; month = 8 ; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2013-08-28' }
+            @{ year = 2012; month = 2 ; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2012-02-29' }
+            @{ year = 2014; month = 12; weekday = 'Wednesday'; schedule = 'last'  ; expect = '2014-12-31' }
+
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Thursday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 5 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-05-16' }
+            @{ year = 2013; month = 6 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-06-13' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'teenth'; expect = '2013-09-19' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'first' ; expect = '2013-09-05' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'first' ; expect = '2013-10-03' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'second'; expect = '2013-09-12' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'second'; expect = '2013-10-10' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'third' ; expect = '2013-09-19' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'third' ; expect = '2013-10-17' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'fourth'; expect = '2013-09-26' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'fourth'; expect = '2013-10-24' }
+            @{ year = 2013; month = 9 ; weekday = 'Thursday'; schedule = 'last'  ; expect = '2013-09-26' }
+            @{ year = 2013; month = 10; weekday = 'Thursday'; schedule = 'last'  ; expect = '2013-10-31' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Friday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 4 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-04-19' }
+            @{ year = 2013; month = 8 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-08-16' }
+            @{ year = 2013; month = 9 ; weekday = 'Friday'; schedule = 'teenth'; expect = '2013-09-13' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'first' ; expect = '2013-11-01' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'first' ; expect = '2013-12-06' }
+            @{ year = 2012; month = 12; weekday = 'Friday'; schedule = 'first' ; expect = '2012-12-07' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'second'; expect = '2013-11-08' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'second'; expect = '2013-12-13' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'third' ; expect = '2013-11-15' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'third' ; expect = '2013-12-20' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'fourth'; expect = '2013-11-22' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'fourth'; expect = '2013-12-27' }
+            @{ year = 2013; month = 11; weekday = 'Friday'; schedule = 'last'  ; expect = '2013-11-29' }
+            @{ year = 2013; month = 12; weekday = 'Friday'; schedule = 'last'  ; expect = '2013-12-27' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Saturday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-02-16' }
+            @{ year = 2013; month = 4 ; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-04-13' }
+            @{ year = 2013; month = 10; weekday = 'Saturday'; schedule = 'teenth'; expect = '2013-10-19' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'first' ; expect = '2013-01-05' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'first' ; expect = '2013-02-02' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'second'; expect = '2013-01-12' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'second'; expect = '2013-02-09' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'third' ; expect = '2013-01-19' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'third' ; expect = '2013-02-16' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'fourth'; expect = '2013-01-26' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'fourth'; expect = '2013-02-23' }
+            @{ year = 2013; month = 1 ; weekday = 'Saturday'; schedule = 'last'  ; expect = '2013-01-26' }
+            @{ year = 2013; month = 2 ; weekday = 'Saturday'; schedule = 'last'  ; expect = '2013-02-23' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+
+    Context "Sunday tests" {
+        It "The <schedule> <weekday> of month <month> in <year>" -ForEach @(
+            @{ year = 2013; month = 5 ; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-05-19' }
+            @{ year = 2013; month = 6 ; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-06-16' }
+            @{ year = 2013; month = 10; weekday = 'Sunday'; schedule = 'teenth'; expect = '2013-10-13' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'first' ; expect = '2013-03-03' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'first' ; expect = '2013-04-07' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'second'; expect = '2013-03-10' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'second'; expect = '2013-04-14' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'third' ; expect = '2013-03-17' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'third' ; expect = '2013-04-21' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'fourth'; expect = '2013-03-24' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'fourth'; expect = '2013-04-28' }
+            @{ year = 2013; month = 3 ; weekday = 'Sunday'; schedule = 'last'  ; expect = '2013-03-31' }
+            @{ year = 2013; month = 4 ; weekday = 'Sunday'; schedule = 'last'  ; expect = '2013-04-28' }
+            @{ year = 2015; month = 2 ; weekday = 'Sunday'; schedule = 'last'  ; expect = '2015-02-22' }
+        ) {
+            $got  = Get-MeetUp -Year $year -Month $month -Weekday $weekday -Schedule $schedule
+            $want = Get-Date $expect
+
+            $got.Date | Should -BeExactly $want.Date
+        }
+    }
+}

--- a/meetup/README.md
+++ b/meetup/README.md
@@ -1,0 +1,66 @@
+# Meetup
+
+Welcome to Meetup on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Recurring monthly meetups are generally scheduled on the given weekday of a given week each month.
+In this exercise you will be given the recurring schedule, along with a month and year, and then asked to find the exact date of the meetup.
+
+For example a meetup might be scheduled on the _first Monday_ of every month.
+You might then be asked to find the date that this meetup will happen in January 2018.
+In other words, you need to determine the date of the first Monday of January 2018.
+
+Similarly, you might be asked to find:
+
+- the third Tuesday of August 2019 (August 20, 2019)
+- the teenth Wednesday of May 2020 (May 13, 2020)
+- the fourth Sunday of July 2021 (July 25, 2021)
+- the last Thursday of November 2022 (November 24, 2022)
+
+The descriptors you are expected to process are: `first`, `second`, `third`, `fourth`, `last`, `teenth`.
+
+Note that descriptor `teenth` is a made-up word.
+
+It refers to the seven numbers that end in '-teen' in English: 13, 14, 15, 16, 17, 18, and 19.
+But general descriptions of dates use ordinal numbers, e.g. the _first_ Monday, the _third_ Tuesday.
+
+For the numbers ending in '-teen', that becomes:
+
+- 13th (thirteenth)
+- 14th (fourteenth)
+- 15th (fifteenth)
+- 16th (sixteenth)
+- 17th (seventeenth)
+- 18th (eighteenth)
+- 19th (nineteenth)
+
+So there are seven numbers ending in '-teen'.
+And there are also seven weekdays (Monday, Tuesday, Wednesday, Thursday, Friday, Saturday, Sunday).
+Therefore, it is guaranteed that each day of the week (Monday, Tuesday, ...) will have exactly one numbered day ending with "teen" each month.
+
+If asked to find the teenth Saturday of August, 1953 (or, alternately the "Saturteenth" of August, 1953), we need to look at the calendar for August 1953:
+
+```plaintext
+    August 1953
+Su Mo Tu We Th Fr Sa
+                   1
+ 2  3  4  5  6  7  8
+ 9 10 11 12 13 14 15
+16 17 18 19 20 21 22
+23 24 25 26 27 28 29
+30 31
+```
+
+The Saturday that has a number ending in '-teen' is August 15, 1953.
+
+## Source
+
+### Created by
+
+- @glaxxie
+
+### Based on
+
+Jeremy Hinegardner mentioned a Boulder meetup that happens on the Wednesteenth of every month - https://twitter.com/copiousfreetime


### PR DESCRIPTION
This commit adds a new function, Get-MeetUp, which solves a date calculation problem for recurring monthly meetups. It also includes extensive testing for this function. The problem and its expected solution are thoroughly detailed in the README file.

@coderabbitai ignore