### PR TITLE
Add nucleotide counting functionality

### DIFF
--- a/nucleotide-count/NucleotideCount.ps1
+++ b/nucleotide-count/NucleotideCount.ps1
@@ -1,0 +1,41 @@
+Function Get-NucleotideCount() {
+    <#
+    .SYNOPSIS
+    Given a single stranded DNA string, compute how many times each nucleotide occurs in the string.
+    
+    .DESCRIPTION
+    The genetic language of every living thing on the planet is DNA.
+    DNA is a large molecule that is built from an extremely long sequence of individual elements called nucleotides.
+    4 types exist in DNA and these differ only slightly and can be represented as the following symbols: 'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' thymine.
+
+    The function counts the occurances of A, C, G and T in the supplied strand.
+    And returns a hashtable in the format:
+
+    @{ A = 2; C = 2; G = 2; T = 3 }
+    
+    .PARAMETER Strand
+    The DNA strand to count
+    
+    .EXAMPLE
+    Get-NucleotideCount -Strand "ACGTAGCTT"
+    
+    Returns: @{ A = 2; C = 2; G = 2; T = 3 }
+    #>
+    [CmdletBinding()]
+    Param(
+        [string]$Strand
+    )
+
+    $nucleotides = @{A = 0; C = 0; G = 0; T = 0}
+
+    foreach ($nucleotide in $Strand.ToCharArray()) {
+        switch ($nucleotide) {
+            'A' { $nucleotides.A++ }
+            'C' { $nucleotides.C++ }
+            'G' { $nucleotides.G++ }
+            'T' { $nucleotides.T++ }
+            default { throw 'Invalid nucleotide in strand' }
+        }
+    }
+    $nucleotides
+}

--- a/nucleotide-count/NucleotideCount.tests.ps1
+++ b/nucleotide-count/NucleotideCount.tests.ps1
@@ -1,0 +1,41 @@
+BeforeAll {
+    . ".\NucleotideCount.ps1"
+}
+
+Describe "NucleotideCountTests" {
+	It "empty strand" {
+        $got = Get-NucleotideCount -Strand ""
+		$want = @{ A = 0; C = 0; G = 0; T = 0 }
+
+		$want.Keys | Should -HaveCount $got.Keys.Count
+        $want.Keys | % {$want[$_] | Should -Be $got[$_]}
+	}
+
+	It "can count one nucleotide in single-character input" {
+		$got = Get-NucleotideCount -Strand "G"
+		$want = @{ A = 0; C = 0; G = 1; T = 0 }
+
+		$want.Keys | Should -HaveCount $got.Keys.Count
+		$want.Keys | % {$want[$_] | Should -Be $got[$_]}
+	}
+
+	It "strand with repeated nucleotide" {
+		$got = Get-NucleotideCount -Strand "GGGGGGG"
+		$want = @{ A = 0; C = 0; G = 7; T = 0 }
+
+		$want.Keys | Should -HaveCount $got.Keys.Count
+		$want.Keys | % {$want[$_] | Should -Be $got[$_]}
+	}
+
+	It "strand with multiple nucleotides" {
+		$got = Get-NucleotideCount -Strand "AGCTTTTCATTCTGACTGCAACGGGCAATATGTCTCTGTGTGGATTAAAAAAAGAGTGTCTGATAGCAGC"
+		$want = @{ A = 20; C = 12; G = 17; T = 21 }
+
+		$want.Keys | Should -HaveCount $got.Keys.Count
+		$want.Keys | % {$want[$_] | Should -Be $got[$_]}
+	}
+
+	It "strand with invalid nucleotides" {
+		{ Get-NucleotideCount -Strand "AGXXACT" } | Should -Throw "Invalid nucleotide in strand"
+	}	
+}

--- a/nucleotide-count/README.md
+++ b/nucleotide-count/README.md
@@ -1,0 +1,43 @@
+# Nucleotide Count
+
+Welcome to Nucleotide Count on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Each of us inherits from our biological parents a set of chemical instructions known as DNA that influence how our bodies are constructed.
+All known life depends on DNA!
+
+> Note: You do not need to understand anything about nucleotides or DNA to complete this exercise.
+
+DNA is a long chain of other chemicals and the most important are the four nucleotides, adenine, cytosine, guanine and thymine.
+A single DNA chain can contain billions of these four nucleotides and the order in which they occur is important!
+We call the order of these nucleotides in a bit of DNA a "DNA sequence".
+
+We represent a DNA sequence as an ordered collection of these four nucleotides and a common way to do that is with a string of characters such as "ATTACG" for a DNA sequence of 6 nucleotides.
+'A' for adenine, 'C' for cytosine, 'G' for guanine, and 'T' for thymine.
+
+Given a string representing a DNA sequence, count how many of each nucleotide is present.
+If the string contains characters that aren't A, C, G, or T then it is invalid and you should signal an error.
+
+For example:
+
+```text
+"GATTACA" -> 'A': 3, 'C': 1, 'G': 1, 'T': 2
+"INVALID" -> error
+```
+
+## Source
+
+### Created by
+
+- @gyssels
+- @meatball133
+
+### Contributed to by
+
+- @kchenery
+
+### Based on
+
+The Calculating DNA Nucleotides_problem at Rosalind - https://rosalind.info/problems/dna/


### PR DESCRIPTION
This commit adds a new function Get-NucleotideCount() to count the occurrences of each nucleotide (A, C, G, T) in a given DNA strand. The function throws an error for invalid nucleotides. Accompanying unit tests and a README.md are included as well.