### PR TITLE
Add accumulate operation and tests in PowerShell

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/coderabbit-overrides.v2.json
+language: "en-US"
+early_access: true
+reviews:
+  request_changes_workflow: false
+  high_level_summary: true
+  poem: true
+  review_status: true
+  collapse_walkthrough: false
+  auto_review:
+    enabled: true
+    ignore_title_keywords:
+      - "WIP"
+      - "DO NOT MERGE"
+    drafts: false
+  path_filters:
+    - '!**/*.md'
+    - '!**/*.tests.ps1'
+chat:
+  auto_reply: true

--- a/accumulate/README.md
+++ b/accumulate/README.md
@@ -1,0 +1,42 @@
+# Accumulate
+
+Welcome to Accumulate on Exercism's PowerShell Track.
+If you need help running the tests or submitting your code, check out `HELP.md`.
+
+## Instructions
+
+Implement the `accumulate` operation, which, given a collection and an operation to perform on each element of the collection, returns a new collection containing the result of applying that operation to each element of the input collection.
+
+Given the collection of numbers:
+
+- 1, 2, 3, 4, 5
+
+And the operation:
+
+- square a number (`x => x * x`)
+
+Your code should be able to produce the collection of squares:
+
+- 1, 4, 9, 16, 25
+
+Check out the test suite to see the expected function signature.
+
+## Restrictions
+
+Keep your hands off that collect/map/fmap/whatchamacallit functionality provided by your standard library!
+Solve this one yourself using other basic tools instead.
+
+## Source
+
+### Created by
+
+- @Kryo
+- @meatball133
+
+### Contributed to by
+
+- @glennj
+
+### Based on
+
+Conversation with James Edward Gray II - http://graysoftinc.com/

--- a/accumulate/accumulate.ps1
+++ b/accumulate/accumulate.ps1
@@ -1,0 +1,39 @@
+Function Get-Accumulation() {
+    <#
+    .SYNOPSIS
+    Accumulate a list of values based on the operation given.
+
+    .DESCRIPTION
+    Given the collection of numbers:
+
+    - 1, 2, 3, 4, 5
+
+    And the operation:
+
+    - square a number `$x = $x * $x`
+
+    Your code should be able to produce the collection of squares:
+
+    - 1, 4, 9, 16, 25
+
+    Check out the test suite to see the expected function signature.
+
+    .PARAMETER List
+    Collection of numbers to perform an operation on.
+
+    .PARAMETER Func
+    A scriptblock containing the operation to perform on the given $List
+
+    .EXAMPLE
+    Get-Accumulation -List 1,2,3,4,5 -Func { <some code here> }
+    #>
+    [CmdletBinding()]
+    Param(
+        [PSObject[]]$List,
+        [scriptblock]$Func
+    )
+
+    $List | ForEach-Object {
+        $Func.Invoke($_)
+    }
+}

--- a/accumulate/accumulate.tests.ps1
+++ b/accumulate/accumulate.tests.ps1
@@ -1,0 +1,40 @@
+BeforeAll {
+    . "./accumulate.ps1"
+}
+
+Describe 'Test Get-Accumulation.ps1' {
+    It "accumulate empty" {
+        $got = Get-Accumulation -List @() -Func { Param($numbers) $numbers * $numbers }
+        $want = @()
+
+        $got | Should -BeExactly $want
+    }
+
+    It "accumulate squares" {
+        $got = Get-Accumulation -List @(1, 2, 3) -Func { Param($numbers) $numbers * $numbers }
+        $want = @(1, 4, 9)
+
+        $got | Should -BeExactly $want
+    }
+
+    It "accumulate upcases" {
+        $got = Get-Accumulation -List @("Hello", "world") -Func { Param($word) $word.ToUpper() }
+        $want = @("HELLO", "WORLD")
+
+        $got | Should -BeExactly $want
+    }
+
+    It "accumulate reversed strings" {
+        $got = Get-Accumulation -List @("the", "quick", "brown", "fox", "etc") -Func { Param($word) $word[-1..-($word.Length)] -join "" }
+        $want = @("eht", "kciuq", "nworb", "xof", "cte")
+
+        $got | Should -BeExactly $want
+    }
+
+    It "accumulate recursively" {
+        $got = Get-Accumulation -List @("a", "b", "c") -Func { Param($letter) return @("1", "2", "3") | ForEach-Object { Invoke-Command -Scriptblock {Param($number) $letter + $number } -ArgumentList $_ } } 
+        $want = @("a1", "a2", "a3", "b1", "b2", "b3", "c1", "c2", "c3")
+
+        $got | Should -BeExactly $want
+    }
+}


### PR DESCRIPTION
This commit introduces a new PowerShell function Get-Accumulation which takes a collection of numbers and an operation to perform on each element of the collection, returning a new collection with the results. Additionally, unit tests for this function have been added. A README has been added to provide instructions and details regarding the accumulate operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced configuration settings for `yaml-language-server` to enable early access, review settings, and chat auto-reply.

- **New Functionality**
  - Added `Get-Accumulation()` PowerShell function to perform operations like squaring each number in a list.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->